### PR TITLE
Optimized publishing because of source map errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-fullscreen-crossbrowser",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-fullscreen-crossbrowser",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "ISC",
       "devDependencies": {
         "@types/react": "^18.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fullscreen-crossbrowser",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "A simple react full-screen component, which will work in both, JS and TS environment.",
   "main": "lib/index.js",
   "scripts": {
@@ -16,6 +16,7 @@
   },
   "files": [
     "lib",
+    "src",
     "LICENSE"
   ],
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
The warning:
`WARNING in ./node_modules/react-fullscreen-crossbrowser/lib/index.js Module Warning (from ./node_modules/source-map-loader/dist/cjs.js): Failed to parse source map from 'C:\Users\XXX\XXX\XXX\XXX\MYPROJECT\node_modules\react-fullscreen-crossbrowser\src\index.tsx' file: Error: ENOENT: no such file or directory, open 'C:\Users\XXX\XXX\XXX\XXX\MYPROJECT\node_modules\react-fullscreen-crossbrowser\src\index.tsx`

...still exists when using the package within a project. So I
- added missing src folder in the package.json for publishing 
- increased version number so that it will be in sync with npm